### PR TITLE
Fix for server URL trailing slash

### DIFF
--- a/app/elements/login-form.html
+++ b/app/elements/login-form.html
@@ -107,6 +107,7 @@
 					return 'username=' + u + '&password=' + Base64.encode(p);
 				},
 				computeURL: function(url) {
+					if (!(this.url.endsWith('/'))) this.url += '/';
 					return this.url + 'auth'
 				},
 				login: function() {


### PR DESCRIPTION
If the user-input for the server url doesn't end with trailing forward slash, add it to the URL in the computeURL function.